### PR TITLE
Make sure LocalCache respects Entry unwrapping and :raw option

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -68,6 +68,7 @@ module ActiveSupport
         end
 
         extend Strategy::LocalCache
+        extend LocalCacheEntryUnwrapAndRaw
       end
 
       ##
@@ -366,6 +367,25 @@ module ActiveSupport
 
       def raise_errors?
         !!@options[:raise_errors]
+      end
+
+      # Make sure LocalCache is giving raw values, not `Entry`s, and
+      # respect `raw` option.
+      module LocalCacheEntryUnwrapAndRaw # :nodoc:
+        protected
+          def read_entry(key, options)
+            retval = super
+            if retval.is_a? ActiveSupport::Cache::Entry
+              # Must have come from LocalStore, unwrap it
+              if options[:raw]
+                retval.value.to_s
+              else
+                retval.value
+              end
+            else
+              retval
+            end
+          end
       end
     end
   end


### PR DESCRIPTION
Trying to set a counter value and using increment while inside a LocalCache block currently fails. LocalCache expects `read_entry`,  `write_entry` and  `delete_entry` to be dealing with `Entry` instances, but Dalli chooses to deal with unwrapped values. This means that writes for raw values would be subsequently read as a raw then `Entry` wrapped object.

This addresses the failure by making sure the `read_entry` interface unwraps potential Entry instances from LocalStore and performs a `to_s` on the unwrapped value if raw is requested. The implementation is similar to the [workaround in activesupport for MemCacheStore's raw support](https://github.com/rails/rails/blob/82e28492e7c581cdeea904464a18eb11118f4ac0/activesupport/lib/active_support/cache/mem_cache_store.rb#L175-L195).

The `write_entry` and `delete_entry` interfaces seem to work sufficiently without this workaround, although there might be other undiscovered complications. It might be possible that `write_entry` is unpredictable and LocalStore may be receiving some Entry-wrapped values and other raw values. Further testing is probably necessary, but this pull should address the main issue.