### PR TITLE
Fix instrumentation of hits for falsey values

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -118,7 +118,7 @@ module ActiveSupport
 
         instrument(:read, name, options) do |payload|
           entry = read_entry(name, options)
-          payload[:hit] = !!entry if payload
+          payload[:hit] = !entry.nil? if payload
           entry
         end
       end

--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -91,7 +91,7 @@ module ActiveSupport
               read_entry(namespaced_name, options).tap do |result|
                 if payload
                   payload[:super_operation] = :fetch
-                  payload[:hit] = !!result
+                  payload[:hit] = !result.nil?
                 end
               end
             end


### PR DESCRIPTION
Handle case when the entry is the boolean value 'false' that it should still be considered a hit.

- I did this as a quick inline fix, will still need to do verification.