### PR TITLE
Connect to unix socket

### DIFF
--- a/lib/dalli/ring.rb
+++ b/lib/dalli/ring.rb
@@ -15,7 +15,7 @@ module Dalli
         continuum = []
         servers.each do |server|
           entry_count_for(server, servers.size, total_weight).times do |idx|
-            hash = Digest::SHA1.hexdigest("#{server.hostname}:#{server.port}:#{idx}")
+            hash = Digest::SHA1.hexdigest("#{server.name}:#{idx}")
             value = Integer("0x#{hash[0..7]}")
             continuum << Dalli::Ring::Entry.new(value, server)
           end

--- a/lib/dalli/socket.rb
+++ b/lib/dalli/socket.rb
@@ -13,17 +13,6 @@ begin
       IO.select(nil, [self], nil, options[:socket_timeout]) || raise(Timeout::Error, "IO timeout")
     end
 
-    def self.open(host, port, server, options = {})
-      addr = Socket.pack_sockaddr_in(port, host)
-      sock = start(addr)
-      sock.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, true)
-      sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true) if options[:keepalive]
-      sock.options = options
-      sock.server = server
-      sock.kgio_wait_writable
-      sock
-    end
-
     alias :write :kgio_write
 
     def readfull(count)
@@ -50,7 +39,30 @@ begin
       end
       value
     end
+  end
 
+  class Dalli::Server::KSocket::TCP < Dalli::Server::KSocket
+    def self.open(host, port, server, options = {})
+      addr = Socket.pack_sockaddr_in(port, host)
+      sock = start(addr)
+      sock.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, true)
+      sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true) if options[:keepalive]
+      sock.options = options
+      sock.server = server
+      sock.kgio_wait_writable
+      sock
+    end
+  end
+
+  class Dalli::Server::KSocket::UNIX < Dalli::Server::KSocket
+    def self.open(path, server, options = {})
+      addr = Socket.pack_sockaddr_un(path)
+      sock = start(addr)
+      sock.options = options
+      sock.server = server
+      sock.kgio_wait_writable
+      sock
+    end
   end
 
   if ::Kgio.respond_to?(:wait_readable=)
@@ -61,48 +73,70 @@ begin
 rescue LoadError
 
   puts "Using standard socket IO (#{RUBY_DESCRIPTION})" if defined?($TESTING) && $TESTING
-  class Dalli::Server::KSocket < TCPSocket
-    attr_accessor :options, :server
+  module Dalli::Server::KSocket
+    module InstanceMethods
+      def readfull(count)
+        value = ''
+        begin
+          loop do
+            value << read_nonblock(count - value.bytesize)
+            break if value.bytesize == count
+          end
+        rescue Errno::EAGAIN, Errno::EWOULDBLOCK
+          if IO.select([self], nil, nil, options[:socket_timeout])
+            retry
+          else
+            raise Timeout::Error, "IO timeout: #{options.inspect}"
+          end
+        end
+        value
+      end
+
+      def read_available
+        value = ''
+        loop do
+          begin
+            value << read_nonblock(8196)
+          rescue Errno::EAGAIN, Errno::EWOULDBLOCK
+            break
+          end
+        end
+        value
+      end
+    end
+
+    def self.included(receiver)
+      receiver.send(:attr_accessor, :options, :server)
+      receiver.send(:include, InstanceMethods)
+    end
+  end
+
+  class Dalli::Server::KSocket::TCP < TCPSocket
+    include Dalli::Server::KSocket
 
     def self.open(host, port, server, options = {})
       Timeout.timeout(options[:socket_timeout]) do
         sock = new(host, port)
         sock.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, true)
         sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true) if options[:keepalive]
-        sock.options = { :host => host, :port => port }.merge(options)
+        sock.options = {:host => host, :port => port}.merge(options)
         sock.server = server
         sock
       end
     end
-
-    def readfull(count)
-      value = ''
-      begin
-        loop do
-          value << read_nonblock(count - value.bytesize)
-          break if value.bytesize == count
-        end
-      rescue Errno::EAGAIN, Errno::EWOULDBLOCK
-        if IO.select([self], nil, nil, options[:socket_timeout])
-          retry
-        else
-          raise Timeout::Error, "IO timeout: #{options.inspect}"
-        end
-      end
-      value
-    end
-
-    def read_available
-      value = ''
-      loop do
-        begin
-          value << read_nonblock(8196)
-        rescue Errno::EAGAIN, Errno::EWOULDBLOCK
-          break
-        end
-      end
-      value
-    end
-
   end
+
+  class Dalli::Server::KSocket::UNIX < UNIXSocket
+    include Dalli::Server::KSocket
+
+    def self.open(path, server, options = {})
+      Timeout.timeout(options[:socket_timeout]) do
+        sock = new(path)
+        sock.options = {:path => path}.merge(options)
+        sock.server = server
+        sock
+      end
+    end
+  end
+
 end

--- a/test/test_network.rb
+++ b/test/test_network.rb
@@ -21,6 +21,16 @@ describe 'Network' do
         end
       end
 
+      it 'handle connection reset with unix socket' do
+        socket_path = MemcachedMock::UNIX_SOCKET_PATH
+        memcached_mock(lambda {|sock| sock.close }, :start_unix, socket_path) do
+          assert_raises Dalli::RingError, :message => "No server available" do
+            dc = Dalli::Client.new(socket_path)
+            dc.get('abc')
+          end
+        end
+      end
+
       it 'handle malformed response' do
         memcached_mock(lambda {|sock| sock.write('123') }) do
           assert_raises Dalli::RingError, :message => "No server available" do

--- a/test/test_ring.rb
+++ b/test/test_ring.rb
@@ -5,8 +5,8 @@ describe 'Ring' do
   describe 'a ring of servers' do
 
     it "have the continuum sorted by value" do
-      servers = [stub(:hostname => "localhost", :port => "11211", :weight => 1),
-                 stub(:hostname => "localhost", :port => "9500", :weight => 1)]
+      servers = [stub(:name => "localhost:11211", :weight => 1),
+                 stub(:name => "localhost:9500", :weight => 1)]
       ring = Dalli::Ring.new(servers, {})
       previous_value = 0
       ring.continuum.each do |entry|

--- a/test/test_sasl.rb
+++ b/test/test_sasl.rb
@@ -11,8 +11,7 @@ describe 'Sasl' do
       @server = mock()
       @server.stubs(:request).returns(true)
       @server.stubs(:weight).returns(1)
-      @server.stubs(:hostname).returns("localhost")
-      @server.stubs(:port).returns("19124")
+      @server.stubs(:name).returns("localhost:19124")
     end
 
     describe 'without authentication credentials' do

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -2,11 +2,26 @@ require 'helper'
 
 describe Dalli::Server do
   describe 'hostname parsing' do
+    it 'handles unix socket with no weight' do
+      s = Dalli::Server.new('/var/run/memcached/sock')
+      assert_equal '/var/run/memcached/sock', s.hostname
+      assert_equal 1, s.weight
+      assert_equal :unix, s.socket_type
+    end
+
+    it 'handles unix socket with a weight' do
+      s = Dalli::Server.new('/var/run/memcached/sock:2')
+      assert_equal '/var/run/memcached/sock', s.hostname
+      assert_equal 2, s.weight
+      assert_equal :unix, s.socket_type
+    end
+
     it 'handles no port or weight' do
       s = Dalli::Server.new('localhost')
       assert_equal 'localhost', s.hostname
       assert_equal 11211, s.port
       assert_equal 1, s.weight
+      assert_equal :tcp, s.socket_type
     end
 
     it 'handles a port, but no weight' do
@@ -14,6 +29,7 @@ describe Dalli::Server do
       assert_equal 'localhost', s.hostname
       assert_equal 11212, s.port
       assert_equal 1, s.weight
+      assert_equal :tcp, s.socket_type
     end
 
     it 'handles a port and a weight' do
@@ -21,6 +37,7 @@ describe Dalli::Server do
       assert_equal 'localhost', s.hostname
       assert_equal 11212, s.port
       assert_equal 2, s.weight
+      assert_equal :tcp, s.socket_type
     end
 
     it 'handles ipv4 addresses' do
@@ -28,6 +45,7 @@ describe Dalli::Server do
       assert_equal '127.0.0.1', s.hostname
       assert_equal 11211, s.port
       assert_equal 1, s.weight
+      assert_equal :tcp, s.socket_type
     end
 
     it 'handles ipv6 addresses' do
@@ -35,6 +53,7 @@ describe Dalli::Server do
       assert_equal '::1', s.hostname
       assert_equal 11211, s.port
       assert_equal 1, s.weight
+      assert_equal :tcp, s.socket_type
     end
 
     it 'handles ipv6 addresses with port' do
@@ -42,6 +61,7 @@ describe Dalli::Server do
       assert_equal '::1', s.hostname
       assert_equal 11212, s.port
       assert_equal 1, s.weight
+      assert_equal :tcp, s.socket_type
     end
 
     it 'handles ipv6 addresses with port and weight' do
@@ -49,6 +69,7 @@ describe Dalli::Server do
       assert_equal '::1', s.hostname
       assert_equal 11212, s.port
       assert_equal 2, s.weight
+      assert_equal :tcp, s.socket_type
     end
 
     it 'handles a FQDN' do
@@ -56,6 +77,7 @@ describe Dalli::Server do
       assert_equal 'my.fqdn.com', s.hostname
       assert_equal 11211, s.port
       assert_equal 1, s.weight
+      assert_equal :tcp, s.socket_type
     end
 
     it 'handles a FQDN with port and weight' do
@@ -63,9 +85,11 @@ describe Dalli::Server do
       assert_equal 'my.fqdn.com', s.hostname
       assert_equal 11212, s.port
       assert_equal 2, s.weight
+      assert_equal :tcp, s.socket_type
     end
 
     it 'throws an exception if the hostname cannot be parsed' do
+      lambda { Dalli::Server.new('[]') }.must_raise Dalli::DalliError
       lambda { Dalli::Server.new('my.fqdn.com:') }.must_raise Dalli::DalliError
       lambda { Dalli::Server.new('my.fqdn.com:11212,:2') }.must_raise Dalli::DalliError
       lambda { Dalli::Server.new('my.fqdn.com:11212:abc') }.must_raise Dalli::DalliError


### PR DESCRIPTION
Please review and merge the connect_to_unix_socket branch. It adds support for connecting to memcached using a unix socket.

The user must use a full pathname (must begin with a slash character: '/') in place of the "host:port" pair argument to Dalli::Client.new method for connecting to a unix socket.