### PR TITLE
Add ability to use Proc as 'expires_in' key

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,11 @@
 Dalli Changelog
 =====================
 
+2.7.5
+==========
+
+- Add ability to use `Proc` as `:expires_in` key (avokhmin, #531)
+
 2.7.4
 ==========
 

--- a/lib/dalli/cas/client.rb
+++ b/lib/dalli/cas/client.rb
@@ -35,7 +35,7 @@ module Dalli
     # Set the key-value pair, verifying existing CAS.
     # Returns the resulting CAS value if succeeded, and falsy otherwise.
     def set_cas(key, value, cas, ttl=nil, options=nil)
-      ttl ||= @options[:expires_in].to_i
+      ttl ||= expires_in_value @options
       perform(:set, key, value, ttl, cas, options)
     end
 
@@ -44,7 +44,7 @@ module Dalli
     # key already exists on the server.  Returns the new CAS value if the
     # operation succeeded, or falsy otherwise.
     def replace_cas(key, value, cas, ttl=nil, options=nil)
-      ttl ||= @options[:expires_in].to_i
+      ttl ||= expires_in_value @options
       perform(:replace, key, value, ttl, cas, options)
     end
 

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -380,8 +380,7 @@ module Dalli
     # options - The Hash with options.
     #           :expires_in - The String, Integer or Proc TTL in seconds.
     #
-    # Returns Numeric number of seconds which should passed as :expires_in key
-    # value, or nil if no state change is to occur.
+    # Returns Numeric number of seconds which should passed as :expires_in key value.
     def expires_in_value(options)
       expires_in = options[:expires_in]
       expires_in = expires_in.call if expires_in.is_a?(Proc)

--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -471,6 +471,7 @@ module Dalli
     # > An expiration time, in seconds. Can be up to 30 days. After 30 days, is treated as a unix timestamp of an exact date.
     MAX_ACCEPTABLE_EXPIRATION_INTERVAL = 30*24*60*60 # 30 days
     def sanitize_ttl(ttl)
+      ttl = ttl.call.to_i if ttl.is_a?(Proc)
       if ttl > MAX_ACCEPTABLE_EXPIRATION_INTERVAL
         Dalli.logger.debug "Expiration interval too long for Memcached, converting to an expiration timestamp"
         Time.now.to_i + ttl.to_i

--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -54,6 +54,9 @@ describe 'ActiveSupport' do
           dvalue = @dalli.fetch('someotherkeywithoutspaces', :expires_in => 1.second) { 123 }
           assert_equal 123, dvalue
 
+          dvalue = @dalli.fetch('somekey', :expires_in => -> { 1.second } ) { 234 }
+          assert_equal 234, dvalue
+
           o = Object.new
           o.instance_variable_set :@foo, 'bar'
           dvalue = @dalli.fetch(rand_key, :raw => true) { o }
@@ -474,6 +477,9 @@ describe 'ActiveSupport' do
         assert_equal 1, @dalli.instance_variable_get(:@data).instance_variable_get(:@options)[:expires_in]
         assert_equal 'foo', @dalli.instance_variable_get(:@data).instance_variable_get(:@options)[:namespace]
         assert_equal ["localhost:#{@port}"], @dalli.instance_variable_get(:@data).instance_variable_get(:@servers)
+
+        @dalli = ActiveSupport::Cache::DalliStore.new("localhost:#{@port}", :expires_in => -> { 2 })
+        assert_equal 2, @dalli.instance_variable_get(:@data).instance_variable_get(:@options)[:expires_in]
       end
     end
   end


### PR DESCRIPTION
Sometimes calculation of `expires_in` can spend a lot of time, so, will be great to do it only if it needed.

Example:

```
[19] pry(main)> x = Rails.cache.fetch('test', expires_in: -> { (1..5).each{ |i| puts(i); sleep(1) }; 10  }) { 'hello' }
Cache read: test ({:expires_in=>#<Proc:0x0000010f058d08@(pry):9 (lambda)>})
Cache generate: test ({:expires_in=>#<Proc:0x0000010f058d08@(pry):9 (lambda)>})
Cache write: test ({:expires_in=>#<Proc:0x0000010f058d08@(pry):9 (lambda)>})
1
2
3
4
5
=> "hello"
[20] pry(main)> x = Rails.cache.fetch('test', expires_in: -> { (1..5).each{ |i| puts(i); sleep(1) }; 10  }) { 'hello' }
Cache read: test ({:expires_in=>#<Proc:0x0000010f1b8f90@(pry):10 (lambda)>})
Cache fetch_hit: test ({:expires_in=>#<Proc:0x0000010f1b8f90@(pry):10 (lambda)>})
=> "hello"
```