### PR TITLE
Escape namespace when using a Regexp to replace it

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -371,7 +371,7 @@ module Dalli
     end
 
     def key_without_namespace(key)
-      (ns = namespace) ? key.sub(%r(\A#{ns}:), '') : key
+      (ns = namespace) ? key.sub(%r(\A#{Regexp.escape ns}:), '') : key
     end
 
     def namespace

--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -204,6 +204,19 @@ describe 'ActiveSupport' do
       end
     end
 
+    it 'support read_multi with special Regexp characters in namespace' do
+      with_activesupport do
+        memcached_persistent(@port) do
+          # /(?!)/ is a contradictory PCRE and should never be able to match
+          @dalli = ActiveSupport::Cache::DalliStore.new("localhost:#{@port}", :namespace => '(?!)')
+          @dalli.write('abc', 123)
+          @dalli.write('xyz', 456)
+
+          assert_equal({'abc' => 123, 'xyz' => 456}, @dalli.read_multi('abc', 'xyz'))
+        end
+      end
+    end
+
     it 'supports fetch_multi' do
       with_activesupport do
         memcached_persistent(@port) do

--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -660,6 +660,16 @@ describe 'Dalli' do
       end
     end
 
+    it 'handle special Regexp characters in namespace with get_multi' do
+      memcached_persistent do |dc, port|
+        # /(?!)/ is a contradictory PCRE and should never be able to match
+        dc = Dalli::Client.new("localhost:#{port}", :namespace => '(?!)')
+        dc.set('a', 1)
+        dc.set('b', 2)
+        assert_equal({'a' => 1, 'b' => 2}, dc.get_multi('a', 'b'))
+      end
+    end
+
     it "handle application marshalling issues" do
       memcached_persistent do |dc|
         old = Dalli.logger


### PR DESCRIPTION
I experienced read_multi results coming back with nil keys.  Eventually I tracked it down to the namespace, which contained a base64-encoded component, but only when it contained the "+" character.

Normal

    irb(main):009:0> Rails.cache.options[:namespace] = 'abc'
    => "abc"
    irb(main):010:0> Rails.cache.write 'foo', 'bar'; puts Rails.cache.read 'foo'; Rails.cache.read_multi 'foo'
    bar
    => {"foo"=>"bar"}

With special characters ("+")

    irb(main):011:0> Rails.cache.options[:namespace] = 'a+c'
    => "a+c"
    irb(main):012:0> Rails.cache.write 'foo', 'bar'; puts Rails.cache.read 'foo'; Rails.cache.read_multi 'foo'
    bar
    => {nil=>"bar"}

Of course, other special regex characters will cause this, too, or possibly raise RegexpErrors (e.g., "[]").  Properly escaping the namespace when using a regexp to remove it from the key solves this issue.